### PR TITLE
MARA-26 : 친구 관계 CRU 기능 구현

### DIFF
--- a/src/main/kotlin/mara/server/domain/friend/Friendship.kt
+++ b/src/main/kotlin/mara/server/domain/friend/Friendship.kt
@@ -20,7 +20,7 @@ class Friendship(
     @JoinColumn(name = "to_user_id")
     val toUser: User,
 
-    var status: String
+    var status: Boolean
     ) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/mara/server/domain/friend/Friendship.kt
+++ b/src/main/kotlin/mara/server/domain/friend/Friendship.kt
@@ -26,4 +26,8 @@ class Friendship(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "friendship_id", nullable = false)
     val friendshipId: Long = 0L
+
+    fun update(friendshipUpdateRequest: FriendshipUpdateRequest) {
+        this.isFriend = friendshipUpdateRequest.isFriend
+    }
 }

--- a/src/main/kotlin/mara/server/domain/friend/Friendship.kt
+++ b/src/main/kotlin/mara/server/domain/friend/Friendship.kt
@@ -1,0 +1,29 @@
+package mara.server.domain.friend
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import mara.server.domain.user.User
+
+@Entity
+class Friendship(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "from_user_id")
+    val fromUser: User,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "to_user_id")
+    val toUser: User,
+
+    var status: String
+    ) {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "friendship_id", nullable = false)
+    val friendshipId: Long = 0L
+}

--- a/src/main/kotlin/mara/server/domain/friend/Friendship.kt
+++ b/src/main/kotlin/mara/server/domain/friend/Friendship.kt
@@ -20,7 +20,6 @@ class Friendship(
     @JoinColumn(name = "to_user_id")
     val toUser: User,
 
-    var isFriend: Boolean
 ) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/mara/server/domain/friend/Friendship.kt
+++ b/src/main/kotlin/mara/server/domain/friend/Friendship.kt
@@ -26,8 +26,4 @@ class Friendship(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "friendship_id", nullable = false)
     val friendshipId: Long = 0L
-
-    fun update(friendshipUpdateRequest: FriendshipUpdateRequest) {
-        this.isFriend = friendshipUpdateRequest.isFriend
-    }
 }

--- a/src/main/kotlin/mara/server/domain/friend/Friendship.kt
+++ b/src/main/kotlin/mara/server/domain/friend/Friendship.kt
@@ -20,7 +20,7 @@ class Friendship(
     @JoinColumn(name = "to_user_id")
     val toUser: User,
 
-    var status: Boolean
+    var isFriend: Boolean
     ) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/mara/server/domain/friend/Friendship.kt
+++ b/src/main/kotlin/mara/server/domain/friend/Friendship.kt
@@ -21,7 +21,7 @@ class Friendship(
     val toUser: User,
 
     var isFriend: Boolean
-    ) {
+) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "friendship_id", nullable = false)

--- a/src/main/kotlin/mara/server/domain/friend/FriendshipController.kt
+++ b/src/main/kotlin/mara/server/domain/friend/FriendshipController.kt
@@ -4,7 +4,6 @@ import mara.server.common.CommonResponse
 import mara.server.common.success
 import mara.server.domain.user.UserNameResponse
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -28,7 +27,7 @@ class FriendshipController(
     }
 
     @PutMapping
-    fun updateFriendship(@RequestBody friendshipUpdateRequest: FriendshipUpdateRequest): CommonResponse<String> {
-        return success(friendshipService.updateFriendship(friendshipUpdateRequest))
+    fun deleteFriendship(@RequestBody friendshipDeleteRequest: FriendshipDeleteRequest): CommonResponse<String> {
+        return success(friendshipService.deleteFriendship(friendshipDeleteRequest))
     }
 }

--- a/src/main/kotlin/mara/server/domain/friend/FriendshipController.kt
+++ b/src/main/kotlin/mara/server/domain/friend/FriendshipController.kt
@@ -2,6 +2,7 @@ package mara.server.domain.friend
 
 import mara.server.common.CommonResponse
 import mara.server.common.success
+import mara.server.domain.user.UserNameResponse
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -17,7 +18,7 @@ class FriendshipController(
 ) {
 
     @PostMapping
-    fun createFriendship(@RequestBody friendshipRequest: FriendshipRequest): CommonResponse<Long> {
+    fun createFriendship(@RequestBody friendshipRequest: FriendshipRequest): CommonResponse<String> {
         return success(friendshipService.createFriendship(friendshipRequest))
     }
 
@@ -26,10 +27,9 @@ class FriendshipController(
         return success(1)
     }
 
-    // TODO FrindshipResponse 로 수정 필요
     @GetMapping
-    fun getFriendshipList(): CommonResponse<List<FriendshipResponse>> {
-        return success(friendshipService.getFriendShipList())
+    fun getFriendshipList(): CommonResponse<List<UserNameResponse>> {
+        return success(friendshipService.getFriendshipList())
     }
 
     // 친구 삭제 기능 수행

--- a/src/main/kotlin/mara/server/domain/friend/FriendshipController.kt
+++ b/src/main/kotlin/mara/server/domain/friend/FriendshipController.kt
@@ -12,11 +12,13 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/friendship")
-class FriendshipController {
+class FriendshipController(
+    private val friendshipService: FriendshipService
+) {
 
     @PostMapping
     fun createFriendship(@RequestBody friendshipRequest: FriendshipRequest): CommonResponse<Long> {
-        return success(1)
+        return success(friendshipService.createFriendship(friendshipRequest))
     }
 
     @GetMapping("{/id}")
@@ -24,9 +26,10 @@ class FriendshipController {
         return success(1)
     }
 
+    // TODO FrindshipResponse 로 수정 필요
     @GetMapping
-    fun getFriendshipList(): CommonResponse<Long> {
-        return success(1)
+    fun getFriendshipList(): CommonResponse<List<Friendship>> {
+        return success(friendshipService.getFriendShipList())
     }
 
     // 친구 삭제 기능 수행

--- a/src/main/kotlin/mara/server/domain/friend/FriendshipController.kt
+++ b/src/main/kotlin/mara/server/domain/friend/FriendshipController.kt
@@ -32,9 +32,8 @@ class FriendshipController(
         return success(friendshipService.getFriendshipList())
     }
 
-    // 친구 삭제 기능 수행
     @PutMapping
-    fun updateFriendship(@RequestBody friendshipUpdateRequest: FriendshipUpdateRequest): CommonResponse<Long> {
-        return success(1)
+    fun updateFriendship(@RequestBody friendshipUpdateRequest: FriendshipUpdateRequest): CommonResponse<String> {
+        return success(friendshipService.updateFriendship(friendshipUpdateRequest))
     }
 }

--- a/src/main/kotlin/mara/server/domain/friend/FriendshipController.kt
+++ b/src/main/kotlin/mara/server/domain/friend/FriendshipController.kt
@@ -1,0 +1,37 @@
+package mara.server.domain.friend
+
+import mara.server.common.CommonResponse
+import mara.server.common.success
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/friendship")
+class FriendshipController {
+
+    @PostMapping
+    fun createFriendship(@RequestBody friendshipRequest: FriendshipRequest): CommonResponse<Long> {
+        return success(1)
+    }
+
+    @GetMapping("{/id}")
+    fun getFriendship(@PathVariable(name = "id") id: Long): CommonResponse<Long> {
+        return success(1)
+    }
+
+    @GetMapping
+    fun getFriendshipList(): CommonResponse<Long> {
+        return success(1)
+    }
+
+    // 친구 삭제 기능 수행
+    @PutMapping
+    fun updateFriendship(@RequestBody friendshipUpdateRequest: FriendshipUpdateRequest): CommonResponse<Long> {
+        return success(1)
+    }
+}

--- a/src/main/kotlin/mara/server/domain/friend/FriendshipController.kt
+++ b/src/main/kotlin/mara/server/domain/friend/FriendshipController.kt
@@ -22,11 +22,6 @@ class FriendshipController(
         return success(friendshipService.createFriendship(friendshipRequest))
     }
 
-    @GetMapping("{/id}")
-    fun getFriendship(@PathVariable(name = "id") id: Long): CommonResponse<Long> {
-        return success(1)
-    }
-
     @GetMapping
     fun getFriendshipList(): CommonResponse<List<UserNameResponse>> {
         return success(friendshipService.getFriendshipList())

--- a/src/main/kotlin/mara/server/domain/friend/FriendshipController.kt
+++ b/src/main/kotlin/mara/server/domain/friend/FriendshipController.kt
@@ -28,7 +28,7 @@ class FriendshipController(
 
     // TODO FrindshipResponse 로 수정 필요
     @GetMapping
-    fun getFriendshipList(): CommonResponse<List<Friendship>> {
+    fun getFriendshipList(): CommonResponse<List<FriendshipResponse>> {
         return success(friendshipService.getFriendShipList())
     }
 

--- a/src/main/kotlin/mara/server/domain/friend/FriendshipDto.kt
+++ b/src/main/kotlin/mara/server/domain/friend/FriendshipDto.kt
@@ -1,5 +1,7 @@
 package mara.server.domain.friend
 
+import mara.server.domain.user.User
+
 data class FriendshipRequest(
     val inviteCode: String
 )
@@ -11,5 +13,16 @@ data class FriendshipUpdateRequest(
 
 data class FriendshipResponse(
     val friendshipId: Long,
-    val friendId: Long
-)
+    val fromFriend: Long,
+    val toFriend: Long
+) {
+    constructor(friendship: Friendship) : this(
+        friendshipId = friendship.friendshipId,
+        fromFriend = friendship.fromUser.userId,
+        toFriend = friendship.toUser.userId
+    )
+}
+
+fun List<Friendship>.toIngredientResponseList(): List<FriendshipResponse> {
+    return this.map { FriendshipResponse(it) }
+}

--- a/src/main/kotlin/mara/server/domain/friend/FriendshipDto.kt
+++ b/src/main/kotlin/mara/server/domain/friend/FriendshipDto.kt
@@ -6,7 +6,10 @@ data class FriendshipRequest(
 
 data class FriendshipUpdateRequest(
     val friendId: Long,
-    val status: Boolean
+    val isFriend: Boolean
 )
 
-// TODO FriendshipResponse
+data class FriendshipResponse(
+    val friendshipId: Long,
+    val friendId: Long
+)

--- a/src/main/kotlin/mara/server/domain/friend/FriendshipDto.kt
+++ b/src/main/kotlin/mara/server/domain/friend/FriendshipDto.kt
@@ -1,0 +1,12 @@
+package mara.server.domain.friend
+
+data class FriendshipRequest(
+    val inviteCode: String
+)
+
+data class FriendshipUpdateRequest(
+    val friendId: Long,
+    val status: Boolean
+)
+
+// TODO FriendshipResponse

--- a/src/main/kotlin/mara/server/domain/friend/FriendshipDto.kt
+++ b/src/main/kotlin/mara/server/domain/friend/FriendshipDto.kt
@@ -4,9 +4,8 @@ data class FriendshipRequest(
     val inviteCode: String
 )
 
-data class FriendshipUpdateRequest(
-    val friendId: Long,
-    val isFriend: Boolean
+data class FriendshipDeleteRequest(
+    val friendId: Long
 )
 
 data class FriendshipResponse(

--- a/src/main/kotlin/mara/server/domain/friend/FriendshipDto.kt
+++ b/src/main/kotlin/mara/server/domain/friend/FriendshipDto.kt
@@ -1,7 +1,5 @@
 package mara.server.domain.friend
 
-import mara.server.domain.user.User
-
 data class FriendshipRequest(
     val inviteCode: String
 )
@@ -23,6 +21,6 @@ data class FriendshipResponse(
     )
 }
 
-fun List<Friendship>.toIngredientResponseList(): List<FriendshipResponse> {
+fun List<Friendship>.toFriendshipResponseList(): List<FriendshipResponse> {
     return this.map { FriendshipResponse(it) }
 }

--- a/src/main/kotlin/mara/server/domain/friend/FriendshipRepository.kt
+++ b/src/main/kotlin/mara/server/domain/friend/FriendshipRepository.kt
@@ -13,4 +13,10 @@ interface FriendshipRepository : JpaRepository<Friendship, Long> {
     fun findAllByFromUserAndIsFriend(
         user: User
     ): Optional<List<Friendship>>
+
+    @Query("select f from Friendship f where (f.fromUser = ?1 and f.toUser = ?2 and f.isFriend = true) or (f.fromUser = ?2 and f.toUser = ?1 and f.isFriend = true)")
+    fun findAllByFromUserAndToUserIsFriend(
+        fromUser: User,
+        toUser: User
+    ): Optional<List<Friendship>>
 }

--- a/src/main/kotlin/mara/server/domain/friend/FriendshipRepository.kt
+++ b/src/main/kotlin/mara/server/domain/friend/FriendshipRepository.kt
@@ -4,21 +4,13 @@ import mara.server.domain.user.User
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
-import java.util.*
+import java.util.Optional
 
 @Repository
 interface FriendshipRepository : JpaRepository<Friendship, Long> {
 
-    @Query("select f from Friendship f where (f.fromUser = ?1 and f.toUser = ?2) or (f.toUser = ?3 and f.fromUser = ?4)")
-    fun findByFromUserAndToUserOrToUserAndFromUser(
-        fromUser1: User,
-        toUser1: User,
-        toUser2: User,
-        fromUser2: User
-    ): Friendship
-
-    @Query("select f from Friendship f where (f.fromUser = ?1 and f.toUser = ?1) or f.isFriend = true")
-    fun findAllByIsFriend(
+    @Query("select f from Friendship f where f.fromUser = ?1 and f.isFriend = true")
+    fun findAllByFromUserAndIsFriend(
         user: User
     ): Optional<List<Friendship>>
 }

--- a/src/main/kotlin/mara/server/domain/friend/FriendshipRepository.kt
+++ b/src/main/kotlin/mara/server/domain/friend/FriendshipRepository.kt
@@ -1,0 +1,19 @@
+package mara.server.domain.friend
+
+import mara.server.domain.user.User
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+
+@Repository
+interface FriendshipRepository : JpaRepository<Friendship, Long> {
+
+    @Query("select f from Friendship f where (f.fromUser = ?1 and f.toUser = ?2) or (f.toUser = ?3 and f.fromUser = ?4)")
+    fun findByFromUserAndToUserOrToUserAndFromUser(
+        fromUser1: User,
+        toUser1: User,
+        toUser2: User,
+        fromUser2: User
+    ): Friendship
+
+}

--- a/src/main/kotlin/mara/server/domain/friend/FriendshipRepository.kt
+++ b/src/main/kotlin/mara/server/domain/friend/FriendshipRepository.kt
@@ -9,13 +9,13 @@ import java.util.Optional
 @Repository
 interface FriendshipRepository : JpaRepository<Friendship, Long> {
 
-    @Query("select f from Friendship f where f.fromUser = ?1 and f.isFriend = true")
-    fun findAllByFromUserAndIsFriend(
+    @Query("select f from Friendship f where f.fromUser = ?1")
+    fun findAllByFromUser(
         user: User
     ): Optional<List<Friendship>>
 
-    @Query("select f from Friendship f where (f.fromUser = ?1 and f.toUser = ?2 and f.isFriend = true) or (f.fromUser = ?2 and f.toUser = ?1 and f.isFriend = true)")
-    fun findAllByFromUserAndToUserIsFriend(
+    @Query("select f from Friendship f where (f.fromUser = ?1 and f.toUser = ?2) or (f.fromUser = ?2 and f.toUser = ?1)")
+    fun findAllByFromUserAndToUser(
         fromUser: User,
         toUser: User
     ): Optional<List<Friendship>>

--- a/src/main/kotlin/mara/server/domain/friend/FriendshipRepository.kt
+++ b/src/main/kotlin/mara/server/domain/friend/FriendshipRepository.kt
@@ -4,6 +4,7 @@ import mara.server.domain.user.User
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import java.util.*
 
 @Repository
 interface FriendshipRepository : JpaRepository<Friendship, Long> {
@@ -16,4 +17,8 @@ interface FriendshipRepository : JpaRepository<Friendship, Long> {
         fromUser2: User
     ): Friendship
 
+    @Query("select f from Friendship f where (f.fromUser = ?1 and f.toUser = ?1) or f.isFriend = true")
+    fun findAllByIsFriend(
+        user: User
+    ): Optional<List<Friendship>>
 }

--- a/src/main/kotlin/mara/server/domain/friend/FriendshipService.kt
+++ b/src/main/kotlin/mara/server/domain/friend/FriendshipService.kt
@@ -44,18 +44,17 @@ class FriendshipService(
         return userNameList
     }
 
-    fun updateFriendship(friendshipUpdateRequest: FriendshipUpdateRequest): String {
+    fun deleteFriendship(friendshipDeleteRequest: FriendshipDeleteRequest): String {
         val currentLoginUser = userService.getCurrentLoginUser()
-        val targetUser = userRepository.findById(friendshipUpdateRequest.friendId).orElseThrow { NoSuchElementException("해당 유저가 존재하지 않습니다. ID: ${friendshipUpdateRequest.friendId}") }
+        val targetUser = userRepository.findById(friendshipDeleteRequest.friendId).orElseThrow { NoSuchElementException("해당 유저가 존재하지 않습니다. ID: ${friendshipDeleteRequest.friendId}") }
 
         val friendshipList = friendshipRepository.findAllByFromUserAndToUserIsFriend(currentLoginUser, targetUser).orElseThrow { NoSuchElementException("친구 관계가 존재하지 않습니다.") }
 
         for (friendship: Friendship in friendshipList) {
-            friendship.update(friendshipUpdateRequest)
-            friendshipRepository.save(friendship)
+            friendshipRepository.delete(friendship)
         }
 
-        return "updated"
+        return deleted
     }
 
     private fun addFriendship(user1: User, user2: User) {

--- a/src/main/kotlin/mara/server/domain/friend/FriendshipService.kt
+++ b/src/main/kotlin/mara/server/domain/friend/FriendshipService.kt
@@ -25,10 +25,9 @@ class FriendshipService(
         return friendshipRepository.save(friendship).friendshipId
     }
 
-    fun getFriendShipList(): List<Friendship> {
+    fun getFriendShipList(): List<FriendshipResponse> {
         val currentLoginUser = userService.getCurrentLoginUser()
         val friendshipList = friendshipRepository.findAllByIsFriend(currentLoginUser).orElseThrow { NoSuchElementException("친구 관계가 존재하지 않습니다.") }
-        return friendshipList
+        return friendshipList.toIngredientResponseList()
     }
-
 }

--- a/src/main/kotlin/mara/server/domain/friend/FriendshipService.kt
+++ b/src/main/kotlin/mara/server/domain/friend/FriendshipService.kt
@@ -31,7 +31,7 @@ class FriendshipService(
 
     fun getFriendshipList(): List<UserNameResponse> {
         val currentLoginUser = userService.getCurrentLoginUser()
-        val friendshipList = friendshipRepository.findAllByFromUserAndIsFriend(currentLoginUser)
+        val friendshipList = friendshipRepository.findAllByFromUser(currentLoginUser)
             .orElseThrow { NoSuchElementException("친구 관계가 존재하지 않습니다.") }
 
         val userNameList: List<UserNameResponse> = friendshipList.map { friendship ->
@@ -46,9 +46,11 @@ class FriendshipService(
 
     fun deleteFriendship(friendshipDeleteRequest: FriendshipDeleteRequest): String {
         val currentLoginUser = userService.getCurrentLoginUser()
-        val targetUser = userRepository.findById(friendshipDeleteRequest.friendId).orElseThrow { NoSuchElementException("해당 유저가 존재하지 않습니다. ID: ${friendshipDeleteRequest.friendId}") }
+        val targetUser = userRepository.findById(friendshipDeleteRequest.friendId)
+            .orElseThrow { NoSuchElementException("해당 유저가 존재하지 않습니다. ID: ${friendshipDeleteRequest.friendId}") }
 
-        val friendshipList = friendshipRepository.findAllByFromUserAndToUserIsFriend(currentLoginUser, targetUser).orElseThrow { NoSuchElementException("친구 관계가 존재하지 않습니다.") }
+        val friendshipList = friendshipRepository.findAllByFromUserAndToUser(currentLoginUser, targetUser)
+            .orElseThrow { NoSuchElementException("친구 관계가 존재하지 않습니다.") }
 
         for (friendship: Friendship in friendshipList) {
             friendshipRepository.delete(friendship)
@@ -61,7 +63,6 @@ class FriendshipService(
         val friendship = Friendship(
             fromUser = user1,
             toUser = user2,
-            isFriend = true
         )
         friendshipRepository.save(friendship)
     }

--- a/src/main/kotlin/mara/server/domain/friend/FriendshipService.kt
+++ b/src/main/kotlin/mara/server/domain/friend/FriendshipService.kt
@@ -56,11 +56,11 @@ class FriendshipService(
     }
 
     private fun addFriendship(user1: User, user2: User) {
-        val friendship2 = Friendship(
+        val friendship = Friendship(
             fromUser = user1,
             toUser = user2,
             isFriend = true
         )
-        friendshipRepository.save(friendship2)
+        friendshipRepository.save(friendship)
     }
 }

--- a/src/main/kotlin/mara/server/domain/friend/FriendshipService.kt
+++ b/src/main/kotlin/mara/server/domain/friend/FriendshipService.kt
@@ -1,0 +1,34 @@
+package mara.server.domain.friend
+
+import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer.FromIntegerArguments
+import mara.server.domain.user.UserRepository
+import mara.server.domain.user.UserService
+import org.springframework.stereotype.Service
+
+@Service
+class FriendshipService(
+    private val friendshipRepository: FriendshipRepository,
+    private val userRepository: UserRepository,
+    private val userService: UserService
+) {
+
+    fun createFriendship(friendshipRequest: FriendshipRequest): Long {
+        val currentUserId = userService.getCurrentLoginUser().userId
+        val fromUser = userRepository.findById(currentUserId).orElseThrow { NoSuchElementException("해당 유저가 존재하지 않습니다. ID: $currentUserId") }
+        val toUser = userRepository.findByInviteCode(friendshipRequest.inviteCode).orElseThrow { NoSuchElementException("해당 초대코드를 가진 사용자가 존재하지 않습니다.") }
+
+        val friendship = Friendship(
+            fromUser = fromUser,
+            toUser = toUser,
+            isFriend = true
+        )
+        return friendshipRepository.save(friendship).friendshipId
+    }
+
+    fun getFriendShipList(): List<Friendship> {
+        val currentLoginUser = userService.getCurrentLoginUser()
+        val friendshipList = friendshipRepository.findAllByIsFriend(currentLoginUser).orElseThrow { NoSuchElementException("친구 관계가 존재하지 않습니다.") }
+        return friendshipList
+    }
+
+}

--- a/src/main/kotlin/mara/server/domain/friend/FriendshipService.kt
+++ b/src/main/kotlin/mara/server/domain/friend/FriendshipService.kt
@@ -1,6 +1,7 @@
 package mara.server.domain.friend
 
-import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer.FromIntegerArguments
+import mara.server.domain.user.User
+import mara.server.domain.user.UserNameResponse
 import mara.server.domain.user.UserRepository
 import mara.server.domain.user.UserService
 import org.springframework.stereotype.Service
@@ -12,22 +13,40 @@ class FriendshipService(
     private val userService: UserService
 ) {
 
-    fun createFriendship(friendshipRequest: FriendshipRequest): Long {
+    fun createFriendship(friendshipRequest: FriendshipRequest): String {
         val currentUserId = userService.getCurrentLoginUser().userId
-        val fromUser = userRepository.findById(currentUserId).orElseThrow { NoSuchElementException("해당 유저가 존재하지 않습니다. ID: $currentUserId") }
-        val toUser = userRepository.findByInviteCode(friendshipRequest.inviteCode).orElseThrow { NoSuchElementException("해당 초대코드를 가진 사용자가 존재하지 않습니다.") }
+        val fromUser = userRepository.findById(currentUserId)
+            .orElseThrow { NoSuchElementException("해당 유저가 존재하지 않습니다. ID: $currentUserId") }
+        val toUser = userRepository.findByInviteCode(friendshipRequest.inviteCode)
+            .orElseThrow { NoSuchElementException("해당 초대코드를 가진 사용자가 존재하지 않습니다.") }
 
-        val friendship = Friendship(
-            fromUser = fromUser,
-            toUser = toUser,
-            isFriend = true
-        )
-        return friendshipRepository.save(friendship).friendshipId
+        addFriendship(fromUser, toUser)
+        addFriendship(toUser, fromUser)
+
+        return "ok"
     }
 
-    fun getFriendShipList(): List<FriendshipResponse> {
+    fun getFriendshipList(): List<UserNameResponse> {
         val currentLoginUser = userService.getCurrentLoginUser()
-        val friendshipList = friendshipRepository.findAllByIsFriend(currentLoginUser).orElseThrow { NoSuchElementException("친구 관계가 존재하지 않습니다.") }
-        return friendshipList.toIngredientResponseList()
+        val friendshipList = friendshipRepository.findAllByFromUserAndIsFriend(currentLoginUser)
+            .orElseThrow { NoSuchElementException("친구 관계가 존재하지 않습니다.") }
+
+        val userNameList: List<UserNameResponse> = friendshipList.map { friendship ->
+            val userId = friendship.toUser.userId
+            val user =
+                userRepository.findById(userId).orElseThrow { NoSuchElementException("해당 유저가 존재하지 않습니다. ID: $userId") }
+            UserNameResponse(user)
+        }
+
+        return userNameList
+    }
+
+    private fun addFriendship(user1: User, user2: User) {
+        val friendship2 = Friendship(
+            fromUser = user1,
+            toUser = user2,
+            isFriend = true
+        )
+        friendshipRepository.save(friendship2)
     }
 }

--- a/src/main/kotlin/mara/server/domain/friend/FriendshipService.kt
+++ b/src/main/kotlin/mara/server/domain/friend/FriendshipService.kt
@@ -13,6 +13,9 @@ class FriendshipService(
     private val userService: UserService
 ) {
 
+    private val ok = "ok"
+    private val deleted = "deleted"
+
     fun createFriendship(friendshipRequest: FriendshipRequest): String {
         val currentUserId = userService.getCurrentLoginUser().userId
         val fromUser = userRepository.findById(currentUserId)
@@ -23,7 +26,7 @@ class FriendshipService(
         addFriendship(fromUser, toUser)
         addFriendship(toUser, fromUser)
 
-        return "ok"
+        return ok
     }
 
     fun getFriendshipList(): List<UserNameResponse> {

--- a/src/main/kotlin/mara/server/domain/friend/FriendshipService.kt
+++ b/src/main/kotlin/mara/server/domain/friend/FriendshipService.kt
@@ -41,6 +41,20 @@ class FriendshipService(
         return userNameList
     }
 
+    fun updateFriendship(friendshipUpdateRequest: FriendshipUpdateRequest): String {
+        val currentLoginUser = userService.getCurrentLoginUser()
+        val targetUser = userRepository.findById(friendshipUpdateRequest.friendId).orElseThrow { NoSuchElementException("해당 유저가 존재하지 않습니다. ID: ${friendshipUpdateRequest.friendId}") }
+
+        val friendshipList = friendshipRepository.findAllByFromUserAndToUserIsFriend(currentLoginUser, targetUser).orElseThrow { NoSuchElementException("친구 관계가 존재하지 않습니다.") }
+
+        for (friendship: Friendship in friendshipList) {
+            friendship.update(friendshipUpdateRequest)
+            friendshipRepository.save(friendship)
+        }
+
+        return "updated"
+    }
+
     private fun addFriendship(user1: User, user2: User) {
         val friendship2 = Friendship(
             fromUser = user1,

--- a/src/main/kotlin/mara/server/domain/user/User.kt
+++ b/src/main/kotlin/mara/server/domain/user/User.kt
@@ -19,6 +19,7 @@ class User(
     val password: String,
     val kakaoId: Long?,
     val googleEmail: String?,
+    val inviteCode: String
 ) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/mara/server/domain/user/UserController.kt
+++ b/src/main/kotlin/mara/server/domain/user/UserController.kt
@@ -32,4 +32,9 @@ class UserController(private val userService: UserService) {
     fun getCurrentLoginUser(): CommonResponse<UserResponse> {
         return success(userService.getCurrentUserInfo())
     }
+
+    @GetMapping("/me/invite-code")
+    fun getCurrentLoginUserInviteCode(): CommonResponse<UserInviteCodeResponse> {
+        return success(userService.getCurrentLoginUserInviteCode())
+    }
 }

--- a/src/main/kotlin/mara/server/domain/user/UserDto.kt
+++ b/src/main/kotlin/mara/server/domain/user/UserDto.kt
@@ -31,3 +31,11 @@ class UserInviteCodeResponse(
         inviteCode = user.inviteCode
     )
 }
+
+class UserNameResponse(
+    val name: String
+) {
+    constructor(user: User) : this(
+        name = user.name
+    )
+}

--- a/src/main/kotlin/mara/server/domain/user/UserDto.kt
+++ b/src/main/kotlin/mara/server/domain/user/UserDto.kt
@@ -33,9 +33,11 @@ class UserInviteCodeResponse(
 }
 
 class UserNameResponse(
+    val userId: Long,
     val name: String
 ) {
     constructor(user: User) : this(
+        userId = user.userId,
         name = user.name
     )
 }

--- a/src/main/kotlin/mara/server/domain/user/UserDto.kt
+++ b/src/main/kotlin/mara/server/domain/user/UserDto.kt
@@ -23,3 +23,11 @@ class UserResponse(
         googleEmail = user.googleEmail
     )
 }
+
+class UserInviteCodeResponse(
+    val inviteCode: String
+) {
+    constructor(user: User) : this(
+        inviteCode = user.inviteCode
+    )
+}

--- a/src/main/kotlin/mara/server/domain/user/UserRepository.kt
+++ b/src/main/kotlin/mara/server/domain/user/UserRepository.kt
@@ -2,10 +2,12 @@ package mara.server.domain.user
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
+import java.util.Optional
 
 @Repository
 interface UserRepository : JpaRepository<User, Long> {
 
     fun findByKakaoId(id: Long): User?
     fun findByGoogleEmail(email: String): User?
+    fun findByInviteCode(inviteCode: String): Optional<User>
 }

--- a/src/main/kotlin/mara/server/domain/user/UserService.kt
+++ b/src/main/kotlin/mara/server/domain/user/UserService.kt
@@ -4,6 +4,7 @@ import mara.server.auth.google.GoogleApiClient
 import mara.server.auth.jwt.JwtProvider
 import mara.server.auth.kakao.KakaoApiClient
 import mara.server.auth.security.getCurrentLoginUserId
+import mara.server.util.StringUtil
 import mara.server.util.logger
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
@@ -32,6 +33,7 @@ class UserService(
             kakaoId = userRequest.kakaoId,
             password = passwordEncoder.encode(userRequest.name),
             googleEmail = userRequest.googleEmail,
+            inviteCode = StringUtil.generateRandomString(8, 11)
         )
         return userRepository.save(user).userId
     }

--- a/src/main/kotlin/mara/server/domain/user/UserService.kt
+++ b/src/main/kotlin/mara/server/domain/user/UserService.kt
@@ -27,6 +27,8 @@ class UserService(
 
     fun getCurrentUserInfo() = UserResponse(getCurrentLoginUser())
 
+    fun getCurrentLoginUserInviteCode() = UserInviteCodeResponse(getCurrentLoginUser())
+
     fun createUser(userRequest: UserRequest): Long {
         val user = User(
             name = userRequest.name,

--- a/src/main/kotlin/mara/server/util/StringUtil.kt
+++ b/src/main/kotlin/mara/server/util/StringUtil.kt
@@ -1,0 +1,16 @@
+package mara.server.util
+
+import kotlin.random.Random
+
+class StringUtil {
+
+    companion object {
+        fun generateRandomString(from: Int, to: Int): String {
+            val charPool = ('A'..'Z') + ('a'..'z') + ('0'..'9')
+
+            return (1..Random.nextInt(from, to))
+                .map { charPool.random() }
+                .joinToString("")
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

## 작업 내용
이 PR은 다음과 같은 작업을 포함하고 있습니다:
- 사용자 회원 가입시 초대 코드 자동 생성
- 사용자간 친구 관계 CRU 기능 구현

## 변경 사항
다음과 같은 파일/부분을 수정했습니다:
- `src/main/kotlin/mara/server/domain/friend/*.kt`: 친구 관계 기능 구현을 위한 controller, service, repository, entity, DTO 
- `src/main/kotlin/mara/server/domain/user/*.kt`: 초대 코드 생성, 조회 구현을 위한 수정 
- 'src/main/kotlin/mara/server/util/StringUtil.kt`: 난수 생성을 위한 util 클래스

## 관련 이슈
이 PR과 관련된 이슈: #MARA-26

## 특이 사항/주의 사항
- 친구 맺기 기능 수행시, 단방향이 아닌 양방향으로 레코드가 생성됨
- ex. A사용자가 B사용자과 친구를 맺을시, `A -> B` 관계 레코드와 `B -> A` 레코드 2개 가 생성

## 테스트
다음과 같은 테스트를 수행했습니다:
- 단위 테스트: swagger 3.0 사용 단위 테스트 수행

## 스크린샷/동영상
해당 사항 없음

## 리뷰어 참고 사항
- 현재 로그인 한 사용자 조회 시, `userService`의 `getCurrentLoginUser() `메소드를 사용해서 기능을 구현하였는데, 이 메소드를 사용하는 것이 맞는지 확인 부탁드립니다!