### PR TITLE
HOTFIX-16 : @PostMapping 중복 매핑 해결

### DIFF
--- a/src/main/kotlin/mara/server/domain/friend/FriendshipController.kt
+++ b/src/main/kotlin/mara/server/domain/friend/FriendshipController.kt
@@ -25,7 +25,7 @@ class FriendshipController(
         return success(friendshipService.getFriendshipList())
     }
 
-    @PostMapping
+    @PostMapping("/delete")
     fun deleteFriendship(@RequestBody friendshipDeleteRequest: FriendshipDeleteRequest): CommonResponse<String> {
         return success(friendshipService.deleteFriendship(friendshipDeleteRequest))
     }


### PR DESCRIPTION
# Pull Request

## 작업 내용
이 PR은 다음과 같은 작업을 포함하고 있습니다:
- FriendshipController 에서 @PostMapping 중복으로 인해 발생한 Cannot map ~ 에러 해결

## 변경 사항
다음과 같은 파일/부분을 수정했습니다:
- `src/main/kotlin/mara/server/domain/friend/FriendshipController.kt`: deleteFriendship @Postmapping에 value "/delete" 추가

## 관련 이슈
이 PR과 관련된 이슈: [16](https://github.com/DDD-Community/fridge-link-server/issues/16)