### PR TITLE
MARA-43 : AWS S3 이미지 업로드 기능 구현

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,6 +7,9 @@ on:
 
 env:
   S3_BUCKET_NAME: mara-s3bucket
+  AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
+  AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+  AWS_REGION: ${{secrets.AWS_REGION}}
   RESOURCE_PATH: ./src/main/resources/application-dev.yml
   CODE_DEPLOY_APPLICATION_NAME: mara-code-deploy
   CODE_DEPLOY_DEPLOYMENT_GROUP_NAME: mara-deploy-group
@@ -39,6 +42,10 @@ jobs:
           oauth.google.client-id: ${{ secrets.GOOGLE_CLIENT_ID }}
           oauth.google.client-secret: ${{ secrets.GOOGLE_CLIENT_SECRET }}
           jwt.secret-key: ${{ secrets.JWT_SECRET_KEY }}
+          cloud.aws.credentials.accessKey: $AWS_ACCESS_KEY_ID
+          cloud.aws.credentials.secretKey: $AWS_SECRET_ACCESS_KEY
+          cloud.aws.region.static: $AWS_REGION
+
 
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
@@ -58,9 +65,9 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-access-key-id: $AWS_ACCESS_KEY_ID
+          aws-secret-access-key: $AWS_SECRET_ACCESS_KEY
+          aws-region: $AWS_REGION
 
         # [5]
       - name: Upload to S3

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,10 @@ dependencies {
 
     // db
     runtimeOnly("org.mariadb.jdbc:mariadb-java-client")
+
+    // s3
+    implementation("org.springframework.cloud:spring-cloud-starter-aws:2.0.1.RELEASE")
+    implementation("javax.xml.bind:jaxb-api:2.3.1")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/mara/server/config/s3/S3Config.kt
+++ b/src/main/kotlin/mara/server/config/s3/S3Config.kt
@@ -1,0 +1,32 @@
+package mara.server.config.s3
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class S3Config {
+    @Value("\${cloud.aws.credentials.accessKey}")
+    private lateinit var accesskey: String
+
+    @Value("\${cloud.aws.credentials.secretKey}")
+    private lateinit var secretKey: String
+
+    @Value("\${cloud.aws.region.static}")
+    private lateinit var region: String
+
+    @Bean
+    fun amazonS3Client(): AmazonS3Client {
+        val basicAWSCredentials: BasicAWSCredentials = BasicAWSCredentials(accesskey, secretKey)
+        return AmazonS3ClientBuilder
+            .standard()
+            .withRegion(region)
+            .withCredentials(AWSStaticCredentialsProvider(basicAWSCredentials))
+            .build()
+            as AmazonS3Client
+    }
+}

--- a/src/main/kotlin/mara/server/domain/s3/S3Controller.kt
+++ b/src/main/kotlin/mara/server/domain/s3/S3Controller.kt
@@ -1,0 +1,25 @@
+package mara.server.domain.s3
+
+import mara.server.common.CommonResponse
+import mara.server.common.success
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+
+@RequestMapping("/s3")
+@RestController
+class S3Controller(
+    private val s3Service: S3Service
+) {
+
+    @PostMapping("/upload", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    fun fileUpload(
+        @RequestParam("image") multipartFile: MultipartFile,
+        @RequestParam("dir", required = false) customDir: String?
+    ): CommonResponse<String> {
+        return success(s3Service.upload(multipartFile, customDir))
+    }
+}

--- a/src/main/kotlin/mara/server/domain/s3/S3Service.kt
+++ b/src/main/kotlin/mara/server/domain/s3/S3Service.kt
@@ -1,0 +1,38 @@
+package mara.server.domain.s3
+
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.model.CannedAccessControlList
+import com.amazonaws.services.s3.model.ObjectMetadata
+import com.amazonaws.services.s3.model.PutObjectRequest
+import com.amazonaws.util.IOUtils
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import org.springframework.web.multipart.MultipartFile
+import java.io.ByteArrayInputStream
+import java.util.UUID
+
+@Service
+class S3Service(
+    private val s3Client: AmazonS3Client,
+    @Value("\${cloud.aws.s3.bucket}")
+    private val bucket: String,
+    @Value("\${cloud.aws.s3.dir}")
+    private val dir: String
+) {
+    fun upload(file: MultipartFile, customDir: String? = dir): String {
+        val fileName = UUID.randomUUID().toString() + "-" + file.originalFilename
+        val objMeta = ObjectMetadata()
+
+        val bytes = IOUtils.toByteArray(file.inputStream)
+        objMeta.contentLength = bytes.size.toLong()
+
+        val byteArrayIs = ByteArrayInputStream(bytes)
+
+        s3Client.putObject(
+            PutObjectRequest(bucket, dir + fileName, byteArrayIs, objMeta)
+                .withCannedAcl(CannedAccessControlList.PublicRead)
+        )
+
+        return s3Client.getUrl(bucket, dir + fileName).toString()
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -20,6 +20,19 @@ oauth:
       auth: https://oauth2.googleapis.com
       api: https://www.googleapis.com
 
+cloud:
+  aws:
+    credentials:
+      accessKey: ${aws-access-key-id}
+      secretKey: ${aws-secret-access-key}
+    s3:
+      bucket: mara-s3bucket
+      dir: upload/
+    region:
+      static: ${aws-region}
+#    stack:
+#      auto: false
+
 jwt:
   secret-key: ${jwt-secret-key}
   access-duration-mils: 2147483647


### PR DESCRIPTION
# Pull Request

## 작업 내용
이 PR은 다음과 같은 작업을 포함하고 있습니다:
- AWS S3 이미지 업로드 기능 구현

## 변경 사항
다음과 같은 파일/부분을 수정했습니다:
- `src/main/kotlin/mara/server/domain/config/s3/S3Config.kt`: S3 설정 작업
- `src/main/kotlin/mara/server/domain/s3/*.kt`: S3 관련 기능 구현 

## 관련 이슈
이 PR과 관련된 이슈: [MARA-43](https://alsehf0316.atlassian.net/browse/MARA-43)

## 특이 사항/주의 사항
- 의존성 추가` implementation("org.springframework.cloud:spring-cloud-starter-aws:2.0.1.RELEASE")`
- 의존성 추가 `implementation("javax.xml.bind:jaxb-api:2.3.1")` : JAXB is unavailable. Will fallback to SDK implementation which may be less performant  [WARN] 경고 메시지 제거

## 테스트
다음과 같은 테스트를 수행했습니다:
- 단위 테스트: swagger 활용 이미지 업로드 테스트

## 리뷰어 참고 사항
- 파일이 기본적으로 S3에 업로드되는 default url은 `upload/` 입니다. 
- 최종 파일명은 `upload/` +` UUID` + `'-'` + `원본파일이름` 입니다.

[MARA-43]: https://alsehf0316.atlassian.net/browse/MARA-43?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ