### PR TITLE
HOTFIX-26 : SecurityFilterChain H2 관련 url 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 src/main/resources/application-local.yml
+src/main/resources/data.sql
 
 ### STS ###
 .apt_generated

--- a/src/main/kotlin/mara/server/auth/security/SecurityConfig.kt
+++ b/src/main/kotlin/mara/server/auth/security/SecurityConfig.kt
@@ -4,7 +4,6 @@ import mara.server.auth.jwt.JwtAccessDeniedHandler
 import mara.server.auth.jwt.JwtAuthenticationEntryPoint
 import mara.server.auth.jwt.JwtFilter
 import mara.server.auth.jwt.JwtProvider
-import org.springframework.boot.autoconfigure.security.servlet.PathRequest
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
@@ -25,7 +24,15 @@ class SecurityConfig(
     private val jwtAccessDeniedHandler: JwtAccessDeniedHandler,
 ) {
 
-    private val allowedUrls = arrayOf("/", "/swagger-ui/**", "/v3/**", "/users/**", "favicon.ico", "/error") // sign-up, sign-in 추가
+    private val allowedUrls = arrayOf(
+        "/",
+        "/swagger-ui/**",
+        "/v3/**",
+        "/users/**",
+        "favicon.ico",
+        "/error",
+        "/h2-console/**"
+    ) // sign-up, sign-in 추가
 
     @Bean
     fun passwordEncoder() = BCryptPasswordEncoder()
@@ -37,9 +44,7 @@ class SecurityConfig(
         http
             .csrf { it.disable() }
             .authorizeHttpRequests {
-                it.requestMatchers(*allowedUrls).permitAll()
-                    .requestMatchers(PathRequest.toH2Console()).permitAll()
-                    .anyRequest().authenticated()
+                it.requestMatchers(*allowedUrls).permitAll().anyRequest().authenticated()
             }
             .headers { it.frameOptions { frameOptions -> frameOptions.disable() } }
             .sessionManagement {


### PR DESCRIPTION
# Pull Request

## 작업 내용
이 PR은 다음과 같은 작업을 포함하고 있습니다:
- SecurityFilterChain H2 관련 url 변경

## 변경 사항
다음과 같은 파일/부분을 수정했습니다:
- `src/main/kotlin/mara/server/auth/security/SecurityConfig.kt`: 
- `requestMatchers(PathRequest.toH2Console()).permitAll()` 삭제
- `allowedUrls` `/h2-console/**` 추가