### PR TITLE
HOTFIX-30 : 회원 가입시 googleEmail 빈값 저장 예외 처리

### DIFF
--- a/src/main/kotlin/mara/server/domain/user/UserService.kt
+++ b/src/main/kotlin/mara/server/domain/user/UserService.kt
@@ -41,7 +41,7 @@ class UserService(
         val newUser = createUser(user)
 
         var authId = newUser.kakaoId.toString()
-        if (newUser.googleEmail != null) authId = newUser.googleEmail!!
+        if (newUser.googleEmail != null && newUser.googleEmail != "") authId = newUser.googleEmail!!
 
         SecurityContextHolder.getContext().authentication =
             UsernamePasswordAuthenticationToken(authId, newUser.password)


### PR DESCRIPTION
# Pull Request

## 작업 내용
이 PR은 다음과 같은 작업을 포함하고 있습니다:
- googleEmail "" 로 들어갈 때 예외 처리


## 변경 사항
다음과 같은 파일/부분을 수정했습니다:
- `src/main/kotlin/mara/server/domain/user/UserService`: 회원 가입시 googleEmail 빈값 저장 예외 처리

