### PR TITLE
ISSUE-42 : 사용자 식자재 수, 나눔 수, 친구 수 조회 API 추가 개발

### DIFF
--- a/src/main/kotlin/mara/server/domain/ingredient/IngredientDetailRepository.kt
+++ b/src/main/kotlin/mara/server/domain/ingredient/IngredientDetailRepository.kt
@@ -73,7 +73,7 @@ class CustomIngredientDetailRepositoryImpl(
     override fun findByRefrigeratorList(refrigeratorList: List<Refrigerator>, limit: Long): List<IngredientDetail> {
         return queryFactory.selectFrom(ingredientDetail)
             .where(ingredientDetail.refrigerator.`in`(refrigeratorList).and(ingredientDetail.isDeleted.isFalse))
-            .orderBy(ingredientDetail.expirationDate.desc()).limit(limit).fetch()
+            .orderBy(ingredientDetail.expirationDate.asc()).limit(limit).fetch()
     }
 
     override fun countByRefrigeratorList(refrigeratorList: List<Refrigerator>): Long {

--- a/src/main/kotlin/mara/server/domain/ingredient/IngredientDetailService.kt
+++ b/src/main/kotlin/mara/server/domain/ingredient/IngredientDetailService.kt
@@ -37,7 +37,7 @@ class IngredientDetailService(
             memo = ingredientDetailRequest.memo,
             addDate = ingredientDetailRequest.addDate,
             expirationDate = ingredientDetailRequest.expirationDate,
-            isDeleted = ingredientDetailRequest.isDeleted
+            isDeleted = false
         )
 
         // 식재료 추가 일자 update

--- a/src/main/kotlin/mara/server/domain/share/ApplyShareRepository.kt
+++ b/src/main/kotlin/mara/server/domain/share/ApplyShareRepository.kt
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface ApplyShareRepository : JpaRepository<ApplyShare, Long> {
     fun existsByUserAndShare(user: User, share: Share): Boolean
+
+    fun countByUser(user: User): Long
 }

--- a/src/main/kotlin/mara/server/domain/share/ShareRepository.kt
+++ b/src/main/kotlin/mara/server/domain/share/ShareRepository.kt
@@ -11,7 +11,9 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.support.PageableExecutionUtils
 
-interface ShareRepository : JpaRepository<Share, Long>, CustomShareRepository
+interface ShareRepository : JpaRepository<Share, Long>, CustomShareRepository {
+    fun countByUser(user: User): Long
+}
 
 interface CustomShareRepository {
     fun findAllMyFriendsShare(pageable: Pageable, status: ShareStatus, user: User): Page<Share>

--- a/src/main/kotlin/mara/server/domain/user/UserController.kt
+++ b/src/main/kotlin/mara/server/domain/user/UserController.kt
@@ -74,4 +74,10 @@ class UserController(
     fun getAllMyShareList(pageable: Pageable, @RequestParam("status") status: String): CommonResponse<Page<ShareResponse>> {
         return success(shareService.getAllMyShareList(pageable, status))
     }
+
+    @GetMapping("/me/statistics")
+    @Operation(summary = "유저의 식자재 수, 나눔 수, 친구 수 조회 API")
+    fun getCountMyStatistics(): CommonResponse<UserStatisticResponse> {
+        return success(userService.getCountMyStatistics())
+    }
 }

--- a/src/main/kotlin/mara/server/domain/user/UserDto.kt
+++ b/src/main/kotlin/mara/server/domain/user/UserDto.kt
@@ -48,3 +48,9 @@ class UserFriendResponse(
         ingredientCount = ingredientCount
     )
 }
+
+class UserStatisticResponse(
+    val ingredientCount: Long,
+    val shareCount: Long,
+    val friendCount: Long
+)


### PR DESCRIPTION
# Pull Request

## 작업 내용
이 PR은 다음과 같은 작업을 포함하고 있습니다:
- 유저의 식자재 수, 나눔 수, 친구 수 조회 API 개발
- 만료일자 정렬 조건 반대로 적용된 부분 수정
- 식자재 상세 생성시 삭제여부(`isDeleted`) `false` 고정값 적용

## 변경 사항
다음과 같은 파일/부분을 수정했습니다:
- `src/main/kotlin/mara/server/domain/user/*.kt`: 사용자 간략 통계 조회 API 개발

## 관련 이슈
이 PR과 관련된 이슈: #42 